### PR TITLE
Allow Building Object Library With cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(aes-gcm C)
+
+file(GLOB SRC_FILES "src/*.c") # Load all files in src folder
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(${PROJECT_NAME} OBJECT ${SRC_FILES})


### PR DESCRIPTION
This will be used for libmicrofido2 as sub dependency.

It builds an object library as this is simpler to integrate into another static library.